### PR TITLE
[bug] fix TLS tests workflow

### DIFF
--- a/.github/workflows/ci_e2e.yml
+++ b/.github/workflows/ci_e2e.yml
@@ -33,7 +33,7 @@ jobs:
         mkdir -p /tmp/certs && cd /tmp/certs
         openssl req -x509 -new -nodes -newkey rsa:2048 -keyout ca.key -out ca.crt -days 3650 -subj '/CN=fluvio-ca' -extensions v3_ca -config <(printf "[req]\ndistinguished_name=dn\n[dn]\n[v3_ca]\nbasicConstraints=CA:TRUE\nkeyUsage=keyCertSign,cRLSign")
         openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr -subj '/CN=localhost'
-        openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 365 -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1\nbasicConstraints=CA:FALSE\nextendedKeyUsage=serverAuth")
+        openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 365 -extfile <(printf "subjectAltName=DNS:localhost,DNS:custom-spu-5001.localhost,IP:127.0.0.1\nbasicConstraints=CA:FALSE\nextendedKeyUsage=serverAuth")
         openssl req -new -newkey rsa:2048 -nodes -keyout client.key -out client.csr -subj '/CN=fluvio-client'
         openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 365 -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1\nbasicConstraints=CA:FALSE\nextendedKeyUsage=clientAuth")
 


### PR DESCRIPTION
This pull request updates the SSL certificate generation process in the CI end-to-end workflow to include an additional DNS entry for `custom-spu-5001.localhost` in the server certificate. This change ensures that the generated certificate is valid for both `localhost` and `custom-spu-5001.localhost`, which are required for testing locally, since records are consumed from the SPU, which recieves a separate subdomain to the SC.

Using this fix, the tests pass on my local machine and in the checks for my fork, so the same should be true for the original repository. No changes to the main code have been made.