### PR TITLE
Prepare client for initial release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-client-cpp"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2024"
 
 [lib]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::ops::DerefMut;
 use fluvio::FluvioConfig as FluvioConfigNative;
 use fluvio::consumer::ConsumerConfigBuilder as ConsumerConfigBuilderNative;
 use fluvio::TopicProducerConfigBuilder as TopicProducerConfigBuilderNative;

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1,14 +1,11 @@
 use fluvio::{
-    Offset as OffsetNative,
-    consumer::Record as NativeRecord,
-    consumer::ConsumerConfigExtBuilder as ConsumerConfigExtBuilderNative,
+    consumer::Record as NativeRecord
 };
 use fluvio_future::task::run_block_on;
 use futures_util::stream::StreamExt;
 use futures_util::stream::Stream;
 use std::pin::Pin;
 use fluvio::dataplane::link::ErrorCode;
-use crate::client::Fluvio;
 
 pub struct Record { pub inner: NativeRecord }
 


### PR DESCRIPTION
This pull request updates the crate version and performs some code cleanup by removing unused imports in the Rust client implementation. The most important changes are:

Version update:

* Bumped the crate version in `Cargo.toml` from `0.0.2` to `0.1.0`, indicating a new release with potentially breaking or significant changes.

Code cleanup:

* Removed unused imports from `src/config.rs` and `src/consumer.rs`, simplifying the code and reducing potential confusion. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL1) [[2]](diffhunk://#diff-add7cbf6be16353596282355f4fbd9685886ca42836c7da62311d56660bc2b11L2-L11)