### PR TITLE
Update CMake configuration for correct library path

### DIFF
--- a/fluvio_client_cppConfig.cmake
+++ b/fluvio_client_cppConfig.cmake
@@ -3,7 +3,7 @@ include(CMakeFindDependencyMacro)
 add_library(fluvio_client_cpp::fluvio_client_cpp STATIC IMPORTED)
 
 set_target_properties(fluvio_client_cpp::fluvio_client_cpp PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/lib/libfluvio_client_cpp.a"
+    IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/target/debug/libfluvio_client_cpp.a"
     INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/include"
 )
 


### PR DESCRIPTION
This pull request makes a minor update to the `fluvio_client_cppConfig.cmake` file, changing the path to the imported static library to point to the `target/debug` directory instead of the previous `lib` directory.

* Updated the `IMPORTED_LOCATION` property for `fluvio_client_cpp::fluvio_client_cpp` to reference the debug build output at `target/debug/libfluvio_client_cpp.a` instead of `lib/libfluvio_client_cpp.a`.