### PR TITLE
Fix release workflow CMake config file path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         find target/release/build -name 'cxx.h' -exec cp {} fluvio-client-cpp-linux-x64/include/rust/ \;
         
         # Add CMake config
-        cp fluvio_client_cppConfig.cmake fluvio-client-cpp-linux-x64/
+        cp build/fluvio_client_cppConfig.cmake fluvio-client-cpp-linux-x64/
 
         tar -czvf fluvio-client-cpp-linux-x64.tar.gz fluvio-client-cpp-linux-x64/
 


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by adjusting the path used to copy the CMake config file. The change ensures that the `fluvio_client_cppConfig.cmake` file is copied from the correct build directory.

* Updated the release workflow to copy `fluvio_client_cppConfig.cmake` from the `build/` directory instead of the root, ensuring the correct configuration file is included in the release package (`.github/workflows/release.yml`).