### PR TITLE
Add topic management and configuration connection methods in FluvioAdmin

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,6 +1,7 @@
 use fluvio::FluvioAdmin as FluvioAdminNative;
 use fluvio_sc_schema::topic::TopicSpec;
 use fluvio_future::task::run_block_on;
+use fluvio_sc_schema::objects::ListFilter;
 
 pub struct FluvioAdmin { pub inner: FluvioAdminNative }
 
@@ -10,8 +11,26 @@ impl FluvioAdmin {
         run_block_on(FluvioAdminNative::connect()).map(|a| Box::new(FluvioAdmin { inner: a })).map_err(|e| e.to_string())
     }
 
+    pub fn connect_with_config(config: &super::FluvioConfig) -> Result<Box<FluvioAdmin>, String> {
+        run_block_on(FluvioAdminNative::connect_with_config(&config.inner))
+            .map(|a| Box::new(FluvioAdmin { inner: a }))
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn topic_exists(self: &Self, topic: &str) -> bool {
+        run_block_on(self.inner.list::<TopicSpec, ListFilter>(Vec::new()))
+            .map(|topics| topics.into_iter().any(|t| t.name == topic))
+            .unwrap_or(false)
+    }
+
     pub fn create_topic(self: &Self, topic: &str, partitions: i32, replicas: i32) -> Result<(), String> {
         run_block_on(self.inner.create(topic.to_string(), false, TopicSpec::new_computed(partitions as u32, replicas as u32, None)))
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn list_topics(&self) -> Result<Vec<String>, String> {
+        run_block_on(self.inner.list::<TopicSpec, ListFilter>(Vec::new()))
+            .map(|topics| topics.into_iter().map(|t| t.name).collect())
             .map_err(|e| e.to_string())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,13 @@ mod ffi {
         /// Connects to the Fluvio Administrative controller
         #[Self = "FluvioAdmin"]
         fn connect() -> Result<Box<FluvioAdmin>>;
+        /// Connects to the Fluvio Administrative controller with explicit config
+        #[Self = "FluvioAdmin"]
+        fn connect_with_config(config: &FluvioConfig) -> Result<Box<FluvioAdmin>>;
+        /// Lists all topics
+        fn list_topics(self: &FluvioAdmin) -> Result<Vec<String>>;
+        /// Checks if a topic exists
+        fn  topic_exists(self: &FluvioAdmin, topic: &str) -> bool;
         /// Dispatches a command to create a new topic
         fn create_topic(self: &FluvioAdmin, topic: &str, partitions: i32, replicas: i32) -> Result<()>;
         /// Dispatches a command to violently delete a topic


### PR DESCRIPTION
This pull request adds new administrative capabilities to the `FluvioAdmin` Rust interface, making it easier to connect with a custom configuration, list topics, and check for topic existence. These enhancements improve the flexibility and usability of the admin API.

**New Connection and Topic Management Features:**

* Added a `connect_with_config` method to `FluvioAdmin`, allowing connections using a custom `FluvioConfig` object. [[1]](diffhunk://#diff-2a76032456d2f72cc6b25681ab39f258aca3ec14dc2035f1cd103cef599dd519R14-R36) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R121-R127)
* Introduced a `list_topics` method to retrieve all topic names managed by the admin. [[1]](diffhunk://#diff-2a76032456d2f72cc6b25681ab39f258aca3ec14dc2035f1cd103cef599dd519R14-R36) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R121-R127)
* Added a `topic_exists` method to check if a specific topic is present. [[1]](diffhunk://#diff-2a76032456d2f72cc6b25681ab39f258aca3ec14dc2035f1cd103cef599dd519R14-R36) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R121-R127)

**FFI Interface Updates:**

* Exposed the new methods (`connect_with_config`, `list_topics`, `topic_exists`) in the FFI module for use from other languages or environments.

**Dependency Updates:**

* Imported `ListFilter` from `fluvio_sc_schema::objects` to support topic listing and existence checks.