### PR TITLE
Add CMake build steps to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
       run: |
         cargo build --release
 
+    - name: Configure CMake
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build CMake project
+      run: cmake --build build --config Release
+
     - name: Package Release Tarball
       run: |
         mkdir -p fluvio-client-cpp-linux-x64/lib


### PR DESCRIPTION
This pull request updates the release workflow to add CMake build steps before packaging the release tarball. The main change is the integration of CMake configuration and build commands into the workflow.

**Build process improvements:**

* Added a step to configure the CMake project using `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to ensure the project is set up for a release build.
* Added a step to build the CMake project with `cmake --build build --config Release`, compiling the source code as part of the workflow.

This was previously missed in #10 but was not caught since a stale build directory still lead to a successful test.