### PR TITLE
Fix installation process and library path for exported target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,48 +14,33 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
 
-    - name: Build C++ Sys Library
-      run: |
-        cargo build --release
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DFLUVIO_CLIENT_CPP_BUILD_TESTS=OFF \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/${{ env.PACKAGE_NAME }}
 
-    - name: Configure CMake
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build CMake project
+        run: cmake --build build --config Release --parallel
 
-    - name: Build CMake project
-      run: cmake --build build --config Release
+      - name: Install CMake project
+        run: cmake --install build --config Release
 
-    - name: Package Release Tarball
-      run: |
-        mkdir -p fluvio-client-cpp-linux-x64/lib
-        mkdir -p fluvio-client-cpp-linux-x64/include/fluvio-client-cpp/src
-        mkdir -p fluvio-client-cpp-linux-x64/include/rust
-        
-        # Copy static library
-        cp target/release/libfluvio_client_cpp.a fluvio-client-cpp-linux-x64/lib/
+      - name: Package Release Tarball
+        run: tar -czvf ${{ env.PACKAGE_NAME }}.tar.gz ${{ env.PACKAGE_NAME }}/
 
-        # Copy manual C/C++ Headers
-        cp -r include/* fluvio-client-cpp-linux-x64/include/
-        
-        # Find and copy generated headers
-        find target/release/build -name 'lib.rs.h' -exec cp {} fluvio-client-cpp-linux-x64/include/fluvio-client-cpp/src/ \;
-        find target/release/build -name 'cxx.h' -exec cp {} fluvio-client-cpp-linux-x64/include/rust/ \;
-        
-        # Add CMake config
-        cp build/fluvio_client_cppConfig.cmake fluvio-client-cpp-linux-x64/
-
-        tar -czvf fluvio-client-cpp-linux-x64.tar.gz fluvio-client-cpp-linux-x64/
-
-    - name: Upload Release Asset
-      uses: softprops/action-gh-release@v1
-      with:
-        files: fluvio-client-cpp-linux-x64.tar.gz
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.PACKAGE_NAME }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,37 @@ list(GET CXX_CORE_HEADER 0 CXX_CORE_HDR)
 get_filename_component(CXX_CORE_DIR ${CXX_CORE_HDR} DIRECTORY)
 get_filename_component(CXX_ROOT_DIR ${CXX_CORE_DIR} DIRECTORY)
 
+# ---------------------------------------------------------------------------
+# Locate the cxx runtime archive (libcxxbridge1.a).
+# ---------------------------------------------------------------------------
+# The `cxx` crate compiles its C++ runtime (rust::cxxbridge1::Str, Vec<T>,
+# Error, etc.) into its OWN static archive under a build-script `out/` dir.
+# This is NOT folded into the crate's staticlib output, so it must be
+# located and linked separately, or every consumer gets undefined
+# references to rust::cxxbridge1::* symbols at final link time.
+file(GLOB_RECURSE FLUVIO_CXXBRIDGE_RUNTIME_LIB "${RUST_TARGET_DIR}/build/cxx-*/out/libcxxbridge1.a")
+list(LENGTH FLUVIO_CXXBRIDGE_RUNTIME_LIB _n_cxxbridge_runtime)
+
+if(_n_cxxbridge_runtime EQUAL 0)
+    message(FATAL_ERROR
+            "Could not find libcxxbridge1.a under ${RUST_TARGET_DIR}/build/cxx-*/out. "
+            "This archive provides the cxx C++ runtime (rust::cxxbridge1::Str, Vec<T>, "
+            "Error, etc.) and is required at link time. Try removing target/ and "
+            "re-running cmake."
+    )
+endif()
+
+if(_n_cxxbridge_runtime GREATER 1)
+    message(FATAL_ERROR
+            "Found multiple candidate libcxxbridge1.a archives under "
+            "${RUST_TARGET_DIR}/build (stale artifacts from a previous build?). "
+            "Run 'cargo clean' and re-configure.\n"
+            "Found: ${FLUVIO_CXXBRIDGE_RUNTIME_LIB}"
+    )
+endif()
+
+list(GET FLUVIO_CXXBRIDGE_RUNTIME_LIB 0 FLUVIO_CXXBRIDGE_RUNTIME_LIB)
+
 # Re-run cargo (and thus cmake) automatically whenever Rust sources change,
 # so incremental `cmake --build .` picks up Rust-side edits without needing
 # a manual reconfigure.
@@ -125,21 +156,50 @@ configure_file(
 )
 
 # ---------------------------------------------------------------------------
+# Imported targets for the two prebuilt static archives
+# ---------------------------------------------------------------------------
+# These replace the old raw-path INTERFACE generator-expression approach,
+# which had no real build dependency edge and could silently drop out of
+# generated link commands (especially across FetchContent boundaries with
+# parallel builds). IMPORTED targets propagate reliably through every level
+# of transitive static linking and carry a proper add_dependencies() edge
+# onto the cargo build step.
+#
+# Link order matters here: fluvio_rust_core calls into the cxxbridge1
+# runtime, so it must be listed BEFORE fluvio_cxxbridge_runtime on the link
+# line, or GNU ld's single-pass archive resolution will leave rust::cxxbridge1::*
+# symbols unresolved again.
+add_library(fluvio_rust_core STATIC IMPORTED GLOBAL)
+set_target_properties(fluvio_rust_core PROPERTIES
+        IMPORTED_LOCATION "${FLUVIO_STATIC_LIB}"
+)
+add_dependencies(fluvio_rust_core fluvio_client_cpp_rust)
+
+add_library(fluvio_cxxbridge_runtime STATIC IMPORTED GLOBAL)
+set_target_properties(fluvio_cxxbridge_runtime PROPERTIES
+        IMPORTED_LOCATION "${FLUVIO_CXXBRIDGE_RUNTIME_LIB}"
+)
+add_dependencies(fluvio_cxxbridge_runtime fluvio_client_cpp_rust)
+
+# ---------------------------------------------------------------------------
 # Library target
 # ---------------------------------------------------------------------------
 add_library(fluvio_client_cpp STATIC ${CXXBRIDGE_SOURCES})
 add_library(ASTRAOS::fluvio_client_cpp ALIAS fluvio_client_cpp)
 add_dependencies(fluvio_client_cpp fluvio_client_cpp_rust)
 
+set_target_properties(fluvio_client_cpp PROPERTIES
+        OUTPUT_NAME "fluvio_client_cpp_bridge"
+)
+
 find_package(Threads REQUIRED)
 
 target_link_libraries(fluvio_client_cpp
         PUBLIC
+        fluvio_rust_core
+        fluvio_cxxbridge_runtime
         Threads::Threads
         ${CMAKE_DL_LIBS}
-        INTERFACE
-        $<BUILD_INTERFACE:${FLUVIO_STATIC_LIB}>
-        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/libfluvio_client_cpp.a>
 )
 
 target_include_directories(fluvio_client_cpp
@@ -190,6 +250,7 @@ install(DIRECTORY
 
 install(FILES
         ${FLUVIO_STATIC_LIB}
+        ${FLUVIO_CXXBRIDGE_RUNTIME_LIB}
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(fluvio_client_cpp
         LANGUAGES CXX C
 )
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -137,7 +139,7 @@ target_link_libraries(fluvio_client_cpp
         ${CMAKE_DL_LIBS}
         INTERFACE
         $<BUILD_INTERFACE:${FLUVIO_STATIC_LIB}>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/libfluvio_client_cpp.a>
+        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/libfluvio_client_cpp.a>
 )
 
 target_include_directories(fluvio_client_cpp
@@ -174,7 +176,6 @@ endif()
 # ---------------------------------------------------------------------------
 # Installation / find_package() support
 # ---------------------------------------------------------------------------
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 install(DIRECTORY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-client-cpp"
-version = "0.2.0"
+version = "0.2.3"
 edition = "2024"
 
 [lib]

--- a/cmake/fluvio_client_cppConfig.cmake.in
+++ b/cmake/fluvio_client_cppConfig.cmake.in
@@ -1,10 +1,22 @@
 @PACKAGE_INIT@
-
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
+
+if(NOT TARGET fluvio_rust_core)
+    add_library(fluvio_rust_core STATIC IMPORTED GLOBAL)
+    set_target_properties(fluvio_rust_core PROPERTIES
+        IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@/libfluvio_client_cpp.a"
+    )
+endif()
+
+if(NOT TARGET fluvio_cxxbridge_runtime)
+    add_library(fluvio_cxxbridge_runtime STATIC IMPORTED GLOBAL)
+    set_target_properties(fluvio_cxxbridge_runtime PROPERTIES
+        IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@/libcxxbridge1.a"
+    )
+endif()
 
 if(NOT TARGET ASTRAOS::fluvio_client_cpp)
     include("${CMAKE_CURRENT_LIST_DIR}/fluvio_client_cppTargets.cmake")
 endif()
-
 check_required_components(fluvio_client_cpp)


### PR DESCRIPTION
This pull request updates the C++ client build and packaging workflow to streamline the release process and improve CMake installation handling. The main changes focus on using CMake's install mechanism for packaging, updating workflow steps, and improving installation path handling.

**Build and packaging workflow improvements:**

* The GitHub Actions release workflow now uses `cmake --install` to install build artifacts into the package directory, replacing manual copy commands, and packages the installed files directly. This simplifies the release process and ensures consistency between local and CI builds.

**CMake configuration enhancements:**

* Added `include(GNUInstallDirs)` at the top of `CMakeLists.txt` to ensure standard installation directories are used.
* Updated the `target_link_libraries` install interface to use `$<INSTALL_PREFIX>` for the static library path, ensuring correct resolution of the install location during package installation.
* Removed a redundant `include(GNUInstallDirs)` from the installation section, as it is now included at the top of the file.